### PR TITLE
Restore background to blockStyle vars in barchart examples

### DIFF
--- a/examples/barchart/horizontal/main.go
+++ b/examples/barchart/horizontal/main.go
@@ -28,16 +28,20 @@ var labelStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.Color("63")) // purple
 
 var blockStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("9")) // red
+	Foreground(lipgloss.Color("9")). // red
+	Background(lipgloss.Color("9"))  // red
 
 var blockStyle2 = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("2")) // green
+	Foreground(lipgloss.Color("2")). // green
+	Background(lipgloss.Color("2"))  // red
 
 var blockStyle3 = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("6")) // cyan
+	Foreground(lipgloss.Color("6")). // cyan
+	Background(lipgloss.Color("6"))  // red
 
 var blockStyle4 = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("3")) // yellow
+	Foreground(lipgloss.Color("3")). // yellow
+	Background(lipgloss.Color("3"))  // red
 
 type model struct {
 	b1 barchart.Model

--- a/examples/barchart/vertical/main.go
+++ b/examples/barchart/vertical/main.go
@@ -28,16 +28,20 @@ var labelStyle = lipgloss.NewStyle().
 	Foreground(lipgloss.Color("63")) // purple
 
 var blockStyle = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("9")) // red
+	Foreground(lipgloss.Color("9")). // red
+	Background(lipgloss.Color("9"))  // red
 
 var blockStyle2 = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("2")) // green
+	Foreground(lipgloss.Color("2")). // green
+	Background(lipgloss.Color("2"))  // red
 
 var blockStyle3 = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("6")) // cyan
+	Foreground(lipgloss.Color("6")). // cyan
+	Background(lipgloss.Color("6"))  // red
 
 var blockStyle4 = lipgloss.NewStyle().
-	Foreground(lipgloss.Color("3")) // yellow
+	Foreground(lipgloss.Color("3")). // yellow
+	Background(lipgloss.Color("3"))  // red
 
 type model struct {
 	b1 barchart.Model


### PR DESCRIPTION
## Summary
This is kind of nitpicky but I just discovered your repo and noticed that the barchart examples seem to always have the gaps you referred to as edge cases in [ntcharts/barchart/barchart.go](https://github.com/sn0rp/ntcharts/blob/eeba8f2851083c387f371ad9ef0b7b93037b979b/barchart/barchart.go#L433). In the corresponding `demo.gif` files for each of the examples, the background is filled in to maintain the intended seamless appearance.  This caveat-free change results in the exact output from those demo images. I'll include screenshots for comparison below.

I checked most of the other examples and they seem consistent with their respective demo images.

I don't care what you do with this PR, I just needed to make sure the barchart functionality wasn't broken for my own use and ran into this, so I figured I'd share - it may help anyone else who glances at the repo to avoid confusion.

## Screenshots
![bar_h_err](https://github.com/user-attachments/assets/7fb23643-b57a-4da8-8546-3ab985c86c54)
![bar_v_err](https://github.com/user-attachments/assets/c066019d-6106-48a4-ac9c-1a17e74c5cb9)
